### PR TITLE
Login Form - remove form.errors from top login message. Fixes SCMS-20

### DIFF
--- a/scarlet/cms/templates/cms/login.html
+++ b/scarlet/cms/templates/cms/login.html
@@ -48,7 +48,7 @@
     {% endif %}
 
     {% if form.non_field_errors or form.errors %}
-    {% for error in form.non_field_errors|add:form.errors %}
+    {% for error in form.non_field_errors %}
     <p class="errornote">
         {{ error }}
     </p>


### PR DESCRIPTION
Removes all errors.

form.non_field_errors is a list
form.errors is dict

They require different iteration methods. Plus field errors should be insitu.