### PR TITLE
SCMS-2 - Add e.preventDefault to openModal instead of a new page

### DIFF
--- a/scarlet/cms/static/scarlet/source/js/views/SelectApi.js
+++ b/scarlet/cms/static/scarlet/source/js/views/SelectApi.js
@@ -155,14 +155,15 @@ const SelectApi = View.extend({
    * Window open trigger
    * @param  {object} event object
    */
-  openPopup(input) {
-    const url = `${this.addUrl}&addInput=${input}`;
+
+  openPopup(e) {
+    e.preventDefault();
     const width = 1025;
     const height = 600;
     const left = screen.width ? (screen.width - width) / 2 : 0;
     const top = screen.height ? (screen.height - height) / 2 : 0;
     const pop = new WindowPopup(
-      url,
+      this.addUrl,
       'addImage',
       [
         `width=${width}`,
@@ -177,7 +178,7 @@ const SelectApi = View.extend({
         'toolbar=no',
         'resizable=no',
       ].join(','),
-      cb,
+      function(){},
     );
     pop.request();
 


### PR DESCRIPTION
JIRA Ticket : [https://wonderfulagency.atlassian.net/browse/SCMS-2](https://wonderfulagency.atlassian.net/browse/SCMS-2)

After Mark updated the back-end, front-end is now relying on SelectAPI component which was not completely done. Not sure what `&addInput` parameter was supposed to do? Let me know if I'm missing something. 