### PR TITLE
nFeature/scms 33 fix wysiwyg link

### DIFF
--- a/scarlet/cms/static/scarlet/source/js/views/editor/rules.js
+++ b/scarlet/cms/static/scarlet/source/js/views/editor/rules.js
@@ -165,7 +165,7 @@ const EditorRules = {
     },
     a: {
       check_attributes: {
-        href: 'preserve', // if you compiled master manually then change this from 'url' to 'href'
+        href: 'href', // if you compiled master manually then change this from 'url' to 'href'
         rel: 'preserve',
         'data-annotation-id': 'preserve',
         'data-annotation-text': 'preserve',


### PR DESCRIPTION
JIRA : [https://wonderfulagency.atlassian.net/browse/SCMS-33](https://wonderfulagency.atlassian.net/browse/SCMS-33)

One of the Editor rule wasn't set properly. As discussed with Vance, we keep this very old wysiwyg library temporary. The reason is asset upload management is already in place and Quill.js integration wasn't as smooth as expected. 