### PR TITLE
Feature/scms 56 wysiwyg validation

### DIFF
--- a/scarlet/cms/static/scarlet/source/js/views/editor/Editor.js
+++ b/scarlet/cms/static/scarlet/source/js/views/editor/Editor.js
@@ -17,6 +17,21 @@ const Editor = View.extend({
     //
     this.setupEditor();
     this.attachCommands();
+    $('form[data-form-id=edit] .button-group--submit .button--primary').on('click', this.onSubmitForm.bind(this));
+  },
+
+  onSubmitForm(){
+    // If Wysiwyg is empty, show native textarea error
+    if(this.$textarea.val().length == 0){
+      this.$textarea.show();
+      this.$textarea.on('keyup', this.onTextAreaKeydown.bind(this));
+    }
+  },
+
+  onTextAreaKeydown(e){
+    this.$textarea.hide();    
+    this.$textarea.off('keyup', this.onTextAreaKeydown.bind(this));
+    $('iframe')[0].contentWindow.document.body.focus();
   },
 
   setupEditor() {

--- a/scarlet/cms/static/scarlet/source/stylesheets/views/_editor.scss
+++ b/scarlet/cms/static/scarlet/source/stylesheets/views/_editor.scss
@@ -1,8 +1,15 @@
 @import '../vendor/wysihtml5';
 
+.editor__content{
+  position: relative;
+}
+
 .editor__textarea {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
 	background-color: $gray-light;
-	padding: 10px;
+  padding: 10px;  
 
 	body {
 		font-size: 22px;

--- a/scarlet/cms/widgets.py
+++ b/scarlet/cms/widgets.py
@@ -808,7 +808,7 @@ class HTMLWidget(widgets.Textarea):
 
     def render(self, *args, **kwargs):
         text = super(HTMLWidget, self).render(*args, **kwargs)
-        return mark_safe(u"<div class=\"editor\">{1} {0}</div>".format(text, render_to_string(self.template)))
+        return mark_safe(u"<div class=\"editor\">{1} <div class=\"editor__content\">{0}</div></div>".format(text, render_to_string(self.template)))
 
 
 class AnnotatedHTMLWidget(widgets.MultiWidget):


### PR DESCRIPTION
Body field in Posts is a wysiwyg component and is marked required. However, there was no error message if the field was left empty. To be consistent with other fields, I was able to fix this by using a trick to render <textarea> native error message 