### PR TITLE
CMS Templates - remove duplicate label tag and close the field-row div

### DIFF
--- a/scarlet/cms/templates/cms/edit.html
+++ b/scarlet/cms/templates/cms/edit.html
@@ -33,24 +33,25 @@
         {% for field in line %}
           <div class='field-row {% if field.is_autoslug %}auto-slug{% endif %} {% if field.is_date %}date{% endif %} {% if field.is_checkbox %}checkbox{% endif %} {% if field.errors %}error-field{% endif %}'
             {% for attr, value in field.label_attrs.items %}
-            data-label-{{attr}}="{{ value }}"
+              data-label-{{attr}}="{{ value }}"
             {% endfor %}
             {% if field.field.id_for_label %}
-            data-label-for="{{ field.field.id_for_label }}"
+              data-label-for="{{ field.field.id_for_label }}"
             {% endif %}
-            data-label-value="{{ field.label_contents }}"
+              data-label-value="{{ field.label_contents }}"
 
             {% if field.field_tag %}
               {% for attr, value in field.field_attrs.items %}
-              data-{{field.field_tag}}-{{attr}}="{{ value }}"
+                data-{{field.field_tag}}-{{attr}}="{{ value }}"
               {% endfor %}
               {% if field.field.value %}
                 data-{{field.field_tag}}-value="{{field.field.value}}"
               {% endif %}
             {% endif %}
-              <label>{{ field.label_tag }}</label>
-              {% if field.field.help_text %}<em class="help">{{ field.field.help_text|safe }}</em>{% endif %}
-              {{ field.field }}
+          >
+            {{ field.label_tag }}
+            {% if field.field.help_text %}<em class="help">{{ field.field.help_text|safe }}</em>{% endif %}
+            {{ field.field }}
             {{ field.errors }}
           </div>
         {% endfor %}


### PR DESCRIPTION
Does not require npm run build.  Just cleans up the template html so tags close properly. 