### PR TITLE
SCMS-50 - Fix empty tags which were encoded and passed through URL pa…

### DIFF
--- a/scarlet/cms/static/scarlet/source/js/views/SelectAsset.js
+++ b/scarlet/cms/static/scarlet/source/js/views/SelectAsset.js
@@ -226,10 +226,14 @@ const SelectAsset = View.extend({
 
     const node = this.$('a.button');
     const params = this.destructParams(node[0].search);
-    let tags = ($(this.$el).data('tags') || '').toLowerCase().split(',');
+    let tags;
+    if($(this.$el).data('tags')){
+      tags = ($(this.$el).data('tags')).toLowerCase().split(',');
+      // autoTags doesn't exist at this point so the following line can't work.
+      //tags = tags.concat(this.autoTags); 
+      params.tags = encodeURIComponent(tags.join(','));
+    }    
 
-    tags = tags.concat(this.autoTags);
-    params.tags = encodeURIComponent(tags.join(','));
     node[0].search = this.constructParams(params);
   },
 


### PR DESCRIPTION
The front-end is adding a tags ULR parameter from the link received from the back-end. If tags was empty that resulted in fail `.split() `.

PS : Build isn't included. I'm afraid we end up with some conflicts if we include the build in each feature branch. 