### PR TITLE
SCMS-65 - Fix Insert Media images through Assets library

### DIFF
--- a/scarlet/cms/static/scarlet/source/js/views/SelectAsset.js
+++ b/scarlet/cms/static/scarlet/source/js/views/SelectAsset.js
@@ -13,7 +13,10 @@ const SelectAsset = View.extend({
     this.url = this.$el.data('api');
     this.addOpen = false;
     this.id = this.$input[0].defaultValue;
-    this.baseUrl = $('.asset__edit-link').data().base;
+
+    if($('.asset__edit-link').length){
+      this.baseUrl = $('.asset__edit-link').data().base;
+    }
   },
 
   /**

--- a/scarlet/cms/templates/cms/insert_media.html
+++ b/scarlet/cms/templates/cms/insert_media.html
@@ -77,25 +77,16 @@
 
         </form>
       </div>
-
       {% if api_link %}
       <div class="insert-image library" style="display: none;">
-        <form>
-
+        <form>            
             <div class="asset" data-api="{{ api_link }}&ftype=image">
-            <div class="asset__preview" style="background-image:url({{ object.url }})"></div>
-              <div class="asset__actions">
-                  <div class="asset__select">
-                      <input data-respond="true" data-attribute="src" type="hidden" value="">
-                      {% if add_link %}
-                        <a class="button button--primary asset__add-link" target="_blank" href="{{ add_link }}">
-                          <i class="fa fa-plus-circle" aria-hidden="true"></i>
-                          Upload New
-                        </a>
-                      {% endif %}
-                  </div>
+              <div class="asset__preview" style="background-image:url({{ object.url }})"></div>             
+              <div class="asset__select">
+                {{ hidden_input }}   
+                <input data-respond="true" data-attribute="src" type="hidden" value="">                      
               </div>
-          </div>
+            </div>
 
           <hr>
 


### PR DESCRIPTION
Inserting images from the Assets Library through Wysiwyg component seems to be relatively new and uncompleted. I was able to progress very quickly with the existing `asset_widget.html `template. However `insert_media.html` won't have the same actions (Upload New / Edit Crop) since we are already in modal and users just want to insert an asset a this point. 