### PR TITLE
[#SCMS-93] - add message to success_response in FormView.form_valid

### DIFF
--- a/scarlet/cms/item.py
+++ b/scarlet/cms/item.py
@@ -248,8 +248,8 @@ class FormView(ModelCMSMixin, ModelFormMixin, ModelCMSView):
                 # from that
                 model = self.get_queryset().model
 
-        # If a form_class hasn't been explicitly defined  
-        # customize_form_widgets still needs to be called so 
+        # If a form_class hasn't been explicitly defined
+        # customize_form_widgets still needs to be called so
         # widgets get updated links
         return model_forms.modelform_factory(model, **params)
 
@@ -429,7 +429,8 @@ class FormView(ModelCMSMixin, ModelFormMixin, ModelCMSView):
         if not new_object and changed_tags and old_tags:
             tag_handler.update_changed_tags(changed_tags, old_tags)
 
-        return self.success_response()
+        msg = f"{self.object} saved"
+        return self.success_response(message=msg)
 
     def success_response(self, message=None):
         """


### PR DESCRIPTION
There is two ways to solve issue with messages, this PR is using existing success_response method.

Second one is to use `base_views->ModelCMSView->write_message`, but here if we don't pass message will get exactly same result cause write_message if don't get message use `self.object saved` with status INFO.

Duplicate messages happens when write_message and returned msg (from write_message method) is passed to success_response.

