### PR TITLE
SCMS-109: Side navigation appearing on action views

### DIFF
--- a/scarlet/cms/actions.py
+++ b/scarlet/cms/actions.py
@@ -65,6 +65,7 @@ class ActionView(ModelCMSMixin, MultipleObjectMixin, ModelCMSView):
 
     object = None
     action_name = None
+    show_navigation = False
 
     def render(self, *args, **kwargs):
         if "action" not in kwargs:
@@ -75,11 +76,14 @@ class ActionView(ModelCMSMixin, MultipleObjectMixin, ModelCMSView):
         return super(ActionView, self).render(*args, **kwargs)
 
     def get_navigation(self):
-        if not self.object and self.name not in self.bundle._meta.action_views:
-            if self.bundle.parent:
-                return self.bundle.parent.get_navigation(self.request, **self.kwargs)
-            return None
-        return super(ActionView, self).get_navigation()
+        nav = None
+        if self.show_navigation:
+            if not self.object and self.name not in self.bundle._meta.action_views:
+                if self.bundle.parent:
+                    nav = self.bundle.parent.get_navigation(self.request, **self.kwargs)
+            else:
+                nav = super(ActionView, self).get_navigation()
+        return nav
 
     def process_action(self, request, queryset):
         """

--- a/scarlet/cms/actions.py
+++ b/scarlet/cms/actions.py
@@ -82,7 +82,7 @@ class ActionView(ModelCMSMixin, MultipleObjectMixin, ModelCMSView):
                 if self.bundle.parent:
                     nav = self.bundle.parent.get_navigation(self.request, **self.kwargs)
             else:
-                nav = super(ActionView, self).get_navigation()
+                nav = super().get_navigation()
         return nav
 
     def process_action(self, request, queryset):


### PR DESCRIPTION
 adding show_navigation flag, and defaulting to False. I cant think of a case where you actually would want the side navigation to appear on an action view, but I dont want to completely remove the functionality. So this makes it a simple override at the bundle level if you do want to flip the nav to be active